### PR TITLE
BE-1 --- Product Metafields + SSR Integration

### DIFF
--- a/components/product/InternalRatingCard.tsx
+++ b/components/product/InternalRatingCard.tsx
@@ -1,0 +1,13 @@
+import { InternalRating } from '../../lib/shopify/types';
+
+export function InternalRatingCard({ rating }: { rating: InternalRating }) {
+  const { image, rating: score, title, description } = rating;
+  return (
+    <div className="flex flex-col items-center gap-2 p-4 border rounded-lg">
+      <img src={image} alt={title} className="h-12 w-12" />
+      <h4 className="text-lg font-semibold">{title}</h4>
+      <p className="text-blue-600 font-bold">{score.toFixed(1)}</p>
+      <p className="text-sm text-neutral-600 text-center">{description}</p>
+    </div>
+  );
+}

--- a/components/product/ProductExtrasSection.tsx
+++ b/components/product/ProductExtrasSection.tsx
@@ -1,0 +1,22 @@
+
+import { InternalRating } from '../../lib/shopify/types';
+import { InternalRatingCard } from './InternalRatingCard';
+
+export function ProductExtrasSection({
+  internalRatings = [],
+}: {
+  internalRatings?: InternalRating[];
+}) {
+  if (internalRatings == null) return null;
+
+  return (
+    <section className="my-10">
+      <h2 className="mb-4 text-2xl font-medium">In-House Ratings</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {internalRatings.map((r, i) => (
+          <InternalRatingCard key={i} rating={r} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/product/product-description.tsx
+++ b/components/product/product-description.tsx
@@ -2,6 +2,7 @@ import { AddToCart } from 'components/cart/add-to-cart';
 import Price from 'components/price';
 import Prose from 'components/prose';
 import { Product } from 'lib/shopify/types';
+import { ProductExtrasSection } from './ProductExtrasSection';
 import { VariantSelector } from './variant-selector';
 
 export function ProductDescription({ product }: { product: Product }) {
@@ -9,12 +10,26 @@ export function ProductDescription({ product }: { product: Product }) {
     <>
       <div className="mb-6 flex flex-col border-b pb-6">
         <h1 className="mb-2 text-5xl font-medium">{product.title}</h1>
+
+        {product.subtitle && (
+        <p className="mb-4 text-lg text-neutral-700">{product.subtitle}</p>
+      )}
+
         <div className="mr-auto w-auto rounded-full bg-blue-600 p-2 text-sm text-white">
           <Price
             amount={product.priceRange.maxVariantPrice.amount}
             currencyCode={product.priceRange.maxVariantPrice.currencyCode}
           />
         </div>
+
+        {product.ratingAverage !== undefined && product.ratingAverage > 0 ? (
+        <div className="mt-2 text-sm text-neutral-600">
+          {product.ratingAverage.toFixed(1)}
+        </div>
+      ) : (
+        <div className="mt-2 text-sm text-neutral-600">Not yet rated</div>
+      )}
+
       </div>
       <VariantSelector options={product.options} variants={product.variants} />
       {product.descriptionHtml ? (
@@ -24,6 +39,17 @@ export function ProductDescription({ product }: { product: Product }) {
         />
       ) : null}
       <AddToCart product={product} />
+      {product.benefits && (
+        <div className="mb-6">
+          <h2 className="mb-2 text-lg font-medium">Benefits</h2>
+          <ul className="list-disc pl-5">
+            {product.benefits.map((benefit) => (
+              <li key={benefit}>{benefit}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <ProductExtrasSection internalRatings={product.internalRatings} />
     </>
   );
 }

--- a/lib/shopify/fragments/product.ts
+++ b/lib/shopify/fragments/product.ts
@@ -1,4 +1,5 @@
 import imageFragment from './image';
+import { productExtrasFragment } from './productExtrasFragment';
 import seoFragment from './seo';
 
 const productFragment = /* GraphQL */ `
@@ -51,6 +52,7 @@ const productFragment = /* GraphQL */ `
         }
       }
     }
+    ...productExtrasFragment
     seo {
       ...seo
     }
@@ -59,6 +61,7 @@ const productFragment = /* GraphQL */ `
   }
   ${imageFragment}
   ${seoFragment}
+  ${productExtrasFragment}
 `;
 
 export default productFragment;

--- a/lib/shopify/fragments/productExtrasFragment.ts
+++ b/lib/shopify/fragments/productExtrasFragment.ts
@@ -1,0 +1,17 @@
+
+export const productExtrasFragment = `
+  fragment productExtrasFragment on Product {
+  subtitle: metafield(namespace: "custom", key: "subtitle") {
+    value
+  }
+  benefits: metafield(namespace: "custom", key: "benefits") {
+    value
+  }
+  ratingAverage: metafield(namespace: "custom", key: "ratingAverage") {
+    value
+  }
+  internalRatings: metafield(namespace: "custom", key: "internalRatings") {
+    value
+  }
+}
+`;

--- a/lib/shopify/index.ts
+++ b/lib/shopify/index.ts
@@ -36,6 +36,7 @@ import {
   Collection,
   Connection,
   Image,
+  InternalRating,
   Menu,
   Page,
   Product,
@@ -177,10 +178,10 @@ const reshapeImages = (images: Connection<Image>, productTitle: string) => {
   });
 };
 
-const reshapeProduct = (
+export const reshapeProduct = (
   product: ShopifyProduct,
-  filterHiddenProducts: boolean = true
-) => {
+  filterHiddenProducts = true
+): Product | undefined => {
   if (
     !product ||
     (filterHiddenProducts && product.tags.includes(HIDDEN_PRODUCT_TAG))
@@ -188,17 +189,39 @@ const reshapeProduct = (
     return undefined;
   }
 
-  const { images, variants, ...rest } = product;
+  const {
+    images,
+    variants,
+    subtitle,
+    benefits,
+    ratingAverage,
+    internalRatings,
+    ...rest
+  } = product;
+
+  const subtitleStr = subtitle?.value || undefined;
+  const benefitsArr = benefits?.value
+    ? JSON.parse(benefits.value) as string[]
+    : [];
+  const ratingAverageNum = ratingAverage?.value
+    ? parseFloat(ratingAverage.value)
+    : undefined;
+  const internalRatingsArr = internalRatings?.value
+    ? JSON.parse(internalRatings.value) as InternalRating[]
+    : [];
 
   return {
     ...rest,
-    images: reshapeImages(images, product.title),
-    variants: removeEdgesAndNodes(variants)
+    images:          reshapeImages(images, product.title),
+    variants:        removeEdgesAndNodes(variants),
+    subtitle:        subtitleStr,
+    benefits:        benefitsArr,
+    ratingAverage:   ratingAverageNum,
+    internalRatings: internalRatingsArr,
   };
 };
 
-const reshapeProducts = (products: ShopifyProduct[]) => {
-  const reshapedProducts = [];
+const reshapeProducts = (products: ShopifyProduct[]) => {  const reshapedProducts = [];
 
   for (const product of products) {
     if (product) {

--- a/lib/shopify/types.ts
+++ b/lib/shopify/types.ts
@@ -68,9 +68,14 @@ export type Page = {
   updatedAt: string;
 };
 
-export type Product = Omit<ShopifyProduct, 'variants' | 'images'> & {
+export type Product = Omit<ShopifyProduct, 'variants' | 'images'| 
+'subtitle' | 'benefits' | 'ratingAverage' | 'internalRatings' > & {
   variants: ProductVariant[];
   images: Image[];
+  subtitle?:       string;
+  benefits?:       string[];
+  ratingAverage?:  number;
+  internalRatings?: InternalRating[];
 };
 
 export type ProductOption = {
@@ -133,6 +138,10 @@ export type ShopifyProduct = {
   seo: SEO;
   tags: string[];
   updatedAt: string;
+  subtitle?: { value: string } | null;
+  benefits?: { value: string } | null;
+  ratingAverage?: { value: string } | null;
+  internalRatings?: { value: string } | null;
 };
 
 export type ShopifyCartOperation = {
@@ -270,3 +279,14 @@ export type ShopifyProductsOperation = {
     sortKey?: string;
   };
 };
+
+export interface InternalRating {
+  image:       string;
+  rating:      number;
+  title:       string;
+  description: string;
+}
+
+export interface Metafield {
+  value: string;
+}


### PR DESCRIPTION
• Added shopify metafield definitions for subtitle, benefits (list), ratingAverage, internalRation. • Extended GraphQL fragment returns those fields.
• getProduct() (RSC) passes them to the React tree.