### PR TITLE
Banner Content CMS (+ Edge Endpoint)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,9 @@
 import { CartProvider } from 'components/cart/cart-context';
 import { Navbar } from 'components/layout/navbar';
+import SiteBannerBar from 'components/SiteBannerBar';
 import { WelcomeToast } from 'components/welcome-toast';
 import { GeistSans } from 'geist/font/sans';
-import { getCart } from 'lib/shopify';
+import { getCart, getSiteBanner } from 'lib/shopify';
 import { baseUrl } from 'lib/utils';
 import { ReactNode } from 'react';
 import { Toaster } from 'sonner';
@@ -30,10 +31,13 @@ export default async function RootLayout({
   // Don't await the fetch, pass the Promise to the context provider
   const cart = getCart();
 
+  const banner = await getSiteBanner();
+
   return (
     <html lang="en" className={GeistSans.variable}>
       <body className="bg-neutral-50 text-black selection:bg-teal-300">
         <CartProvider cartPromise={cart}>
+          {banner && <SiteBannerBar banner={banner} />}
           <Navbar />
           <main>
             {children}

--- a/components/SiteBannerBar.tsx
+++ b/components/SiteBannerBar.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { SiteBannerBarProps } from "lib/shopify/types";
+import Link from "next/link";
+
+export default function SiteBannerBar({ banner }: SiteBannerBarProps) {
+  const { message, ctaType, linkUrl, discountCode } = banner;
+
+  const handleCopy = () => {
+    if (!discountCode) return;
+    navigator.clipboard.writeText(discountCode);
+    // You can replace this with a custom toast or UI notification // lets add some shadcn or heroUI compoenent here
+    alert(`Copied code: ${discountCode}`);
+  };
+
+  return (
+    <div className="bg-blue-600 text-white flex items-center justify-between px-4 py-2">
+      <span className="font-medium">{message}</span>
+      {ctaType === "link" && linkUrl && (
+        <Link href={linkUrl} className="underline font-semibold">
+          Learn more
+        </Link>
+      )}
+      {ctaType === "copyCode" && discountCode && (
+        <button
+          onClick={handleCopy}
+          className="bg-white text-blue-600 font-semibold px-3 py-1 rounded"
+        >
+          Copy Code
+        </button>
+      )}
+    </div>
+  );
+}

--- a/lib/shopify/queries/site-banner.ts
+++ b/lib/shopify/queries/site-banner.ts
@@ -1,0 +1,14 @@
+
+export const getSiteBannerQuery =`
+  query SiteBanner {
+  metaobjects(type: "site", first: 1) {
+    nodes {
+      id
+      settings: field(key: "banner_settings") {
+        value
+      }
+    }
+  }
+}
+
+`

--- a/lib/shopify/types.ts
+++ b/lib/shopify/types.ts
@@ -290,3 +290,24 @@ export interface InternalRating {
 export interface Metafield {
   value: string;
 }
+
+export interface SiteBanner {
+  message:       string
+  ctaType:       'link' | 'copyCode' | 'none'
+  linkUrl?:      string
+  discountCode?: string
+}
+
+export interface GetSiteBannerResponse {
+  data: any;
+  metaobjects: {
+    nodes: Array<{
+      id: string
+      settings: { value: string } | null
+    }>
+  }
+}
+
+export interface SiteBannerBarProps {
+  banner: SiteBanner;
+}


### PR DESCRIPTION
• Added a single Site Banner metafield (namespace: site, key: banner_settings, type: json) defined with: message, expiresAt, ctaType, linkUrl, discountCode. 
• Added a new GraphQL query lib/shopify/queries/site-banner.ts fetches that metafield via shop { metafield(...) } and returns a typed object SiteBanner. 
• Helper getSiteBanner() (exported from lib/shopify) caches at the RSC layer.