### PR TITLE
Display variant images

### DIFF
--- a/components/product/variant-selector.tsx
+++ b/components/product/variant-selector.tsx
@@ -1,8 +1,9 @@
-'use client';
+"use client";
 
-import clsx from 'clsx';
-import { useProduct, useUpdateURL } from 'components/product/product-context';
-import { ProductOption, ProductVariant } from 'lib/shopify/types';
+import clsx from "clsx";
+import { useProduct, useUpdateURL } from "components/product/product-context";
+import { ProductOption, ProductVariant } from "lib/shopify/types";
+import Image from "next/image";
 
 type Combination = {
   id: string;
@@ -12,7 +13,7 @@ type Combination = {
 
 export function VariantSelector({
   options,
-  variants
+  variants,
 }: {
   options: ProductOption[];
   variants: ProductVariant[];
@@ -20,7 +21,8 @@ export function VariantSelector({
   const { state, updateOption } = useProduct();
   const updateURL = useUpdateURL();
   const hasNoOptionsOrJustOneOption =
-    !options.length || (options.length === 1 && options[0]?.values.length === 1);
+    !options.length ||
+    (options.length === 1 && options[0]?.values.length === 1);
 
   if (hasNoOptionsOrJustOneOption) {
     return null;
@@ -30,9 +32,12 @@ export function VariantSelector({
     id: variant.id,
     availableForSale: variant.availableForSale,
     ...variant.selectedOptions.reduce(
-      (accumulator, option) => ({ ...accumulator, [option.name.toLowerCase()]: option.value }),
-      {}
-    )
+      (accumulator, option) => ({
+        ...accumulator,
+        [option.name.toLowerCase()]: option.value,
+      }),
+      {},
+    ),
   }));
 
   return options.map((option) => (
@@ -42,20 +47,31 @@ export function VariantSelector({
         <dd className="flex flex-wrap gap-3">
           {option.values.map((value) => {
             const optionNameLowerCase = option.name.toLowerCase();
+            const variantImage = variants.find((variant) =>
+              variant.selectedOptions.some(
+                (opt) =>
+                  opt.name.toLowerCase() === optionNameLowerCase &&
+                  opt.value === value,
+              ),
+            )?.image;
 
             // Base option params on current selectedOptions so we can preserve any other param state.
             const optionParams = { ...state, [optionNameLowerCase]: value };
 
             // Filter out invalid options and check if the option combination is available for sale.
-            const filtered = Object.entries(optionParams).filter(([key, value]) =>
-              options.find(
-                (option) => option.name.toLowerCase() === key && option.values.includes(value)
-              )
+            const filtered = Object.entries(optionParams).filter(
+              ([key, value]) =>
+                options.find(
+                  (option) =>
+                    option.name.toLowerCase() === key &&
+                    option.values.includes(value),
+                ),
             );
             const isAvailableForSale = combinations.find((combination) =>
               filtered.every(
-                ([key, value]) => combination[key] === value && combination.availableForSale
-              )
+                ([key, value]) =>
+                  combination[key] === value && combination.availableForSale,
+              ),
             );
 
             // The option is active if it's in the selected options.
@@ -70,19 +86,29 @@ export function VariantSelector({
                 key={value}
                 aria-disabled={!isAvailableForSale}
                 disabled={!isAvailableForSale}
-                title={`${option.name} ${value}${!isAvailableForSale ? ' (Out of Stock)' : ''}`}
+                title={`${option.name} ${value}${!isAvailableForSale ? " (Out of Stock)" : ""}`}
                 className={clsx(
-                  'flex min-w-[48px] items-center justify-center rounded-full border bg-neutral-100 px-2 py-1 text-sm',
+                  "flex h-12 w-12 items-center justify-center rounded-full border bg-neutral-100 text-sm",
                   {
-                    'cursor-default ring-2 ring-blue-600': isActive,
-                    'ring-1 ring-transparent transition duration-300 ease-in-out hover:ring-blue-600':
+                    "cursor-default ring-2 ring-blue-600": isActive,
+                    "ring-1 ring-transparent transition duration-300 ease-in-out hover:ring-blue-600":
                       !isActive && isAvailableForSale,
-                    'relative z-10 cursor-not-allowed overflow-hidden bg-neutral-100 text-neutral-500 ring-1 ring-neutral-300 before:absolute before:inset-x-0 before:-z-10 before:h-px before:-rotate-45 before:bg-neutral-300 before:transition-transform':
-                      !isAvailableForSale
-                  }
+                    "relative z-10 cursor-not-allowed overflow-hidden bg-neutral-100 text-neutral-500 ring-1 ring-neutral-300 before:absolute before:inset-x-0 before:-z-10 before:h-px before:-rotate-45 before:bg-neutral-300 before:transition-transform":
+                      !isAvailableForSale,
+                  },
                 )}
               >
-                {value}
+                {variantImage?.url ? (
+                  <Image
+                    src={variantImage.url}
+                    alt={variantImage.altText || value}
+                    width={48}
+                    height={48}
+                    className="h-full w-full rounded-full object-cover"
+                  />
+                ) : (
+                  value
+                )}
               </button>
             );
           })}

--- a/lib/shopify/fragments/product.ts
+++ b/lib/shopify/fragments/product.ts
@@ -1,6 +1,6 @@
-import imageFragment from './image';
-import { productExtrasFragment } from './productExtrasFragment';
-import seoFragment from './seo';
+import imageFragment from "./image";
+import { productExtrasFragment } from "./productExtrasFragment";
+import seoFragment from "./seo";
 
 const productFragment = /* GraphQL */ `
   fragment product on Product {
@@ -38,6 +38,9 @@ const productFragment = /* GraphQL */ `
           price {
             amount
             currencyCode
+          }
+          image {
+            ...image
           }
         }
       }

--- a/lib/shopify/index.ts
+++ b/lib/shopify/index.ts
@@ -1,37 +1,37 @@
 import {
   HIDDEN_PRODUCT_TAG,
   SHOPIFY_GRAPHQL_API_ENDPOINT,
-  TAGS
-} from 'lib/constants';
-import { isShopifyError } from 'lib/type-guards';
-import { ensureStartsWith } from 'lib/utils';
+  TAGS,
+} from "lib/constants";
+import { isShopifyError } from "lib/type-guards";
+import { ensureStartsWith } from "lib/utils";
 import {
   unstable_cacheLife as cacheLife,
   unstable_cacheTag as cacheTag,
-  revalidateTag
-} from 'next/cache';
-import { cookies, headers } from 'next/headers';
-import { NextRequest, NextResponse } from 'next/server';
+  revalidateTag,
+} from "next/cache";
+import { cookies, headers } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
 import {
   addToCartMutation,
   createCartMutation,
   editCartItemsMutation,
-  removeFromCartMutation
-} from './mutations/cart';
-import { getCartQuery } from './queries/cart';
+  removeFromCartMutation,
+} from "./mutations/cart";
+import { getCartQuery } from "./queries/cart";
 import {
   getCollectionProductsQuery,
   getCollectionQuery,
-  getCollectionsQuery
-} from './queries/collection';
-import { getMenuQuery } from './queries/menu';
-import { getPageQuery, getPagesQuery } from './queries/page';
+  getCollectionsQuery,
+} from "./queries/collection";
+import { getMenuQuery } from "./queries/menu";
+import { getPageQuery, getPagesQuery } from "./queries/page";
 import {
   getProductQuery,
   getProductRecommendationsQuery,
-  getProductsQuery
-} from './queries/product';
-import { getSiteBannerQuery } from './queries/site-banner';
+  getProductsQuery,
+} from "./queries/product";
+import { getSiteBannerQuery } from "./queries/site-banner";
 import {
   Cart,
   Collection,
@@ -59,23 +59,23 @@ import {
   ShopifyProductsOperation,
   ShopifyRemoveFromCartOperation,
   ShopifyUpdateCartOperation,
-  SiteBanner
-} from './types';
+  SiteBanner,
+} from "./types";
 
 const domain = process.env.SHOPIFY_STORE_DOMAIN
-  ? ensureStartsWith(process.env.SHOPIFY_STORE_DOMAIN, 'https://')
-  : '';
+  ? ensureStartsWith(process.env.SHOPIFY_STORE_DOMAIN, "https://")
+  : "";
 const endpoint = `${domain}${SHOPIFY_GRAPHQL_API_ENDPOINT}`;
 const key = process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN!;
 
 type ExtractVariables<T> = T extends { variables: object }
-  ? T['variables']
+  ? T["variables"]
   : never;
 
 export async function shopifyFetch<T>({
   headers,
   query,
-  variables
+  variables,
 }: {
   headers?: HeadersInit;
   query: string;
@@ -83,16 +83,16 @@ export async function shopifyFetch<T>({
 }): Promise<{ status: number; body: T } | never> {
   try {
     const result = await fetch(endpoint, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        'X-Shopify-Storefront-Access-Token': key,
-        ...headers
+        "Content-Type": "application/json",
+        "X-Shopify-Storefront-Access-Token": key,
+        ...headers,
       },
       body: JSON.stringify({
         ...(query && { query }),
-        ...(variables && { variables })
-      })
+        ...(variables && { variables }),
+      }),
     });
 
     const body = await result.json();
@@ -103,21 +103,21 @@ export async function shopifyFetch<T>({
 
     return {
       status: result.status,
-      body
+      body,
     };
   } catch (e) {
     if (isShopifyError(e)) {
       throw {
-        cause: e.cause?.toString() || 'unknown',
+        cause: e.cause?.toString() || "unknown",
         status: e.status || 500,
         message: e.message,
-        query
+        query,
       };
     }
 
     throw {
       error: e,
-      query
+      query,
     };
   }
 }
@@ -129,19 +129,19 @@ const removeEdgesAndNodes = <T>(array: Connection<T>): T[] => {
 const reshapeCart = (cart: ShopifyCart): Cart => {
   if (!cart.cost?.totalTaxAmount) {
     cart.cost.totalTaxAmount = {
-      amount: '0.0',
-      currencyCode: cart.cost.totalAmount.currencyCode
+      amount: "0.0",
+      currencyCode: cart.cost.totalAmount.currencyCode,
     };
   }
 
   return {
     ...cart,
-    lines: removeEdgesAndNodes(cart.lines)
+    lines: removeEdgesAndNodes(cart.lines),
   };
 };
 
 const reshapeCollection = (
-  collection: ShopifyCollection
+  collection: ShopifyCollection,
 ): Collection | undefined => {
   if (!collection) {
     return undefined;
@@ -149,7 +149,7 @@ const reshapeCollection = (
 
   return {
     ...collection,
-    path: `/search/${collection.handle}`
+    path: `/search/${collection.handle}`,
   };
 };
 
@@ -176,14 +176,14 @@ const reshapeImages = (images: Connection<Image>, productTitle: string) => {
     const filename = image.url.match(/.*\/(.*)\..*/)?.[1];
     return {
       ...image,
-      altText: image.altText || `${productTitle} - ${filename}`
+      altText: image.altText || `${productTitle} - ${filename}`,
     };
   });
 };
 
 export const reshapeProduct = (
   product: ShopifyProduct,
-  filterHiddenProducts = true
+  filterHiddenProducts = true,
 ): Product | undefined => {
   if (
     !product ||
@@ -204,27 +204,43 @@ export const reshapeProduct = (
 
   const subtitleStr = subtitle?.value || undefined;
   const benefitsArr = benefits?.value
-    ? JSON.parse(benefits.value) as string[]
+    ? (JSON.parse(benefits.value) as string[])
     : [];
   const ratingAverageNum = ratingAverage?.value
     ? parseFloat(ratingAverage.value)
     : undefined;
   const internalRatingsArr = internalRatings?.value
-    ? JSON.parse(internalRatings.value) as InternalRating[]
+    ? (JSON.parse(internalRatings.value) as InternalRating[])
     : [];
+
+  const reshapedVariants = removeEdgesAndNodes(variants).map((variant) => {
+    if (variant.image) {
+      const filename = variant.image.url.match(/.*\/(.*)\..*/)?.[1];
+      return {
+        ...variant,
+        image: {
+          ...variant.image,
+          altText: variant.image.altText || `${product.title} - ${filename}`,
+        },
+      };
+    }
+
+    return variant;
+  });
 
   return {
     ...rest,
-    images:          reshapeImages(images, product.title),
-    variants:        removeEdgesAndNodes(variants),
-    subtitle:        subtitleStr,
-    benefits:        benefitsArr,
-    ratingAverage:   ratingAverageNum,
+    images: reshapeImages(images, product.title),
+    variants: reshapedVariants,
+    subtitle: subtitleStr,
+    benefits: benefitsArr,
+    ratingAverage: ratingAverageNum,
     internalRatings: internalRatingsArr,
   };
 };
 
-const reshapeProducts = (products: ShopifyProduct[]) => {  const reshapedProducts = [];
+const reshapeProducts = (products: ShopifyProduct[]) => {
+  const reshapedProducts = [];
 
   for (const product of products) {
     if (product) {
@@ -241,56 +257,56 @@ const reshapeProducts = (products: ShopifyProduct[]) => {  const reshapedProduct
 
 export async function createCart(): Promise<Cart> {
   const res = await shopifyFetch<ShopifyCreateCartOperation>({
-    query: createCartMutation
+    query: createCartMutation,
   });
 
   return reshapeCart(res.body.data.cartCreate.cart);
 }
 
 export async function addToCart(
-  lines: { merchandiseId: string; quantity: number }[]
+  lines: { merchandiseId: string; quantity: number }[],
 ): Promise<Cart> {
-  const cartId = (await cookies()).get('cartId')?.value!;
+  const cartId = (await cookies()).get("cartId")?.value!;
   const res = await shopifyFetch<ShopifyAddToCartOperation>({
     query: addToCartMutation,
     variables: {
       cartId,
-      lines
-    }
+      lines,
+    },
   });
   return reshapeCart(res.body.data.cartLinesAdd.cart);
 }
 
 export async function removeFromCart(lineIds: string[]): Promise<Cart> {
-  const cartId = (await cookies()).get('cartId')?.value!;
+  const cartId = (await cookies()).get("cartId")?.value!;
   const res = await shopifyFetch<ShopifyRemoveFromCartOperation>({
     query: removeFromCartMutation,
     variables: {
       cartId,
-      lineIds
-    }
+      lineIds,
+    },
   });
 
   return reshapeCart(res.body.data.cartLinesRemove.cart);
 }
 
 export async function updateCart(
-  lines: { id: string; merchandiseId: string; quantity: number }[]
+  lines: { id: string; merchandiseId: string; quantity: number }[],
 ): Promise<Cart> {
-  const cartId = (await cookies()).get('cartId')?.value!;
+  const cartId = (await cookies()).get("cartId")?.value!;
   const res = await shopifyFetch<ShopifyUpdateCartOperation>({
     query: editCartItemsMutation,
     variables: {
       cartId,
-      lines
-    }
+      lines,
+    },
   });
 
   return reshapeCart(res.body.data.cartLinesUpdate.cart);
 }
 
 export async function getCart(): Promise<Cart | undefined> {
-  const cartId = (await cookies()).get('cartId')?.value;
+  const cartId = (await cookies()).get("cartId")?.value;
 
   if (!cartId) {
     return undefined;
@@ -298,7 +314,7 @@ export async function getCart(): Promise<Cart | undefined> {
 
   const res = await shopifyFetch<ShopifyCartOperation>({
     query: getCartQuery,
-    variables: { cartId }
+    variables: { cartId },
   });
 
   // Old carts becomes `null` when you checkout.
@@ -310,17 +326,17 @@ export async function getCart(): Promise<Cart | undefined> {
 }
 
 export async function getCollection(
-  handle: string
+  handle: string,
 ): Promise<Collection | undefined> {
-  'use cache';
+  "use cache";
   cacheTag(TAGS.collections);
-  cacheLife('days');
+  cacheLife("days");
 
   const res = await shopifyFetch<ShopifyCollectionOperation>({
     query: getCollectionQuery,
     variables: {
-      handle
-    }
+      handle,
+    },
   });
 
   return reshapeCollection(res.body.data.collection);
@@ -329,23 +345,23 @@ export async function getCollection(
 export async function getCollectionProducts({
   collection,
   reverse,
-  sortKey
+  sortKey,
 }: {
   collection: string;
   reverse?: boolean;
   sortKey?: string;
 }): Promise<Product[]> {
-  'use cache';
+  "use cache";
   cacheTag(TAGS.collections, TAGS.products);
-  cacheLife('days');
+  cacheLife("days");
 
   const res = await shopifyFetch<ShopifyCollectionProductsOperation>({
     query: getCollectionProductsQuery,
     variables: {
       handle: collection,
       reverse,
-      sortKey: sortKey === 'CREATED_AT' ? 'CREATED' : sortKey
-    }
+      sortKey: sortKey === "CREATED_AT" ? "CREATED" : sortKey,
+    },
   });
 
   if (!res.body.data.collection) {
@@ -354,60 +370,60 @@ export async function getCollectionProducts({
   }
 
   return reshapeProducts(
-    removeEdgesAndNodes(res.body.data.collection.products)
+    removeEdgesAndNodes(res.body.data.collection.products),
   );
 }
 
 export async function getCollections(): Promise<Collection[]> {
-  'use cache';
+  "use cache";
   cacheTag(TAGS.collections);
-  cacheLife('days');
+  cacheLife("days");
 
   const res = await shopifyFetch<ShopifyCollectionsOperation>({
-    query: getCollectionsQuery
+    query: getCollectionsQuery,
   });
   const shopifyCollections = removeEdgesAndNodes(res.body?.data?.collections);
   const collections = [
     {
-      handle: '',
-      title: 'All',
-      description: 'All products',
+      handle: "",
+      title: "All",
+      description: "All products",
       seo: {
-        title: 'All',
-        description: 'All products'
+        title: "All",
+        description: "All products",
       },
-      path: '/search',
-      updatedAt: new Date().toISOString()
+      path: "/search",
+      updatedAt: new Date().toISOString(),
     },
     // Filter out the `hidden` collections.
     // Collections that start with `hidden-*` need to be hidden on the search page.
     ...reshapeCollections(shopifyCollections).filter(
-      (collection) => !collection.handle.startsWith('hidden')
-    )
+      (collection) => !collection.handle.startsWith("hidden"),
+    ),
   ];
 
   return collections;
 }
 
 export async function getMenu(handle: string): Promise<Menu[]> {
-  'use cache';
+  "use cache";
   cacheTag(TAGS.collections);
-  cacheLife('days');
+  cacheLife("days");
 
   const res = await shopifyFetch<ShopifyMenuOperation>({
     query: getMenuQuery,
     variables: {
-      handle
-    }
+      handle,
+    },
   });
 
   return (
     res.body?.data?.menu?.items.map((item: { title: string; url: string }) => ({
       title: item.title,
       path: item.url
-        .replace(domain, '')
-        .replace('/collections', '/search')
-        .replace('/pages', '')
+        .replace(domain, "")
+        .replace("/collections", "/search")
+        .replace("/pages", ""),
     })) || []
   );
 }
@@ -415,7 +431,7 @@ export async function getMenu(handle: string): Promise<Menu[]> {
 export async function getPage(handle: string): Promise<Page> {
   const res = await shopifyFetch<ShopifyPageOperation>({
     query: getPageQuery,
-    variables: { handle }
+    variables: { handle },
   });
 
   return res.body.data.pageByHandle;
@@ -423,39 +439,39 @@ export async function getPage(handle: string): Promise<Page> {
 
 export async function getPages(): Promise<Page[]> {
   const res = await shopifyFetch<ShopifyPagesOperation>({
-    query: getPagesQuery
+    query: getPagesQuery,
   });
 
   return removeEdgesAndNodes(res.body.data.pages);
 }
 
 export async function getProduct(handle: string): Promise<Product | undefined> {
-  'use cache';
+  "use cache";
   cacheTag(TAGS.products);
-  cacheLife('days');
+  cacheLife("days");
 
   const res = await shopifyFetch<ShopifyProductOperation>({
     query: getProductQuery,
     variables: {
-      handle
-    }
+      handle,
+    },
   });
 
   return reshapeProduct(res.body.data.product, false);
 }
 
 export async function getProductRecommendations(
-  productId: string
+  productId: string,
 ): Promise<Product[]> {
-  'use cache';
+  "use cache";
   cacheTag(TAGS.products);
-  cacheLife('days');
+  cacheLife("days");
 
   const res = await shopifyFetch<ShopifyProductRecommendationsOperation>({
     query: getProductRecommendationsQuery,
     variables: {
-      productId
-    }
+      productId,
+    },
   });
 
   return reshapeProducts(res.body.data.productRecommendations);
@@ -464,23 +480,23 @@ export async function getProductRecommendations(
 export async function getProducts({
   query,
   reverse,
-  sortKey
+  sortKey,
 }: {
   query?: string;
   reverse?: boolean;
   sortKey?: string;
 }): Promise<Product[]> {
-  'use cache';
+  "use cache";
   cacheTag(TAGS.products);
-  cacheLife('days');
+  cacheLife("days");
 
   const res = await shopifyFetch<ShopifyProductsOperation>({
     query: getProductsQuery,
     variables: {
       query,
       reverse,
-      sortKey
-    }
+      sortKey,
+    },
   });
 
   return reshapeProducts(removeEdgesAndNodes(res.body.data.products));
@@ -491,22 +507,22 @@ export async function revalidate(req: NextRequest): Promise<NextResponse> {
   // We always need to respond with a 200 status code to Shopify,
   // otherwise it will continue to retry the request.
   const collectionWebhooks = [
-    'collections/create',
-    'collections/delete',
-    'collections/update'
+    "collections/create",
+    "collections/delete",
+    "collections/update",
   ];
   const productWebhooks = [
-    'products/create',
-    'products/delete',
-    'products/update'
+    "products/create",
+    "products/delete",
+    "products/update",
   ];
-  const topic = (await headers()).get('x-shopify-topic') || 'unknown';
-  const secret = req.nextUrl.searchParams.get('secret');
+  const topic = (await headers()).get("x-shopify-topic") || "unknown";
+  const secret = req.nextUrl.searchParams.get("secret");
   const isCollectionUpdate = collectionWebhooks.includes(topic);
   const isProductUpdate = productWebhooks.includes(topic);
 
   if (!secret || secret !== process.env.SHOPIFY_REVALIDATION_SECRET) {
-    console.error('Invalid revalidation secret.');
+    console.error("Invalid revalidation secret.");
     return NextResponse.json({ status: 401 });
   }
 
@@ -530,26 +546,26 @@ export async function revalidate(req: NextRequest): Promise<NextResponse> {
  * Fetch and cache the site-wide banner from a metaobject.
  */
 export async function getSiteBanner(): Promise<SiteBanner | null> {
-  'use cache'
-  cacheTag('site-banner')
+  "use cache";
+  cacheTag("site-banner");
   const { body } = await shopifyFetch<GetSiteBannerResponse>({
     query: getSiteBannerQuery,
-  })
+  });
 
-  const node = body.data.metaobjects.nodes[0]
-  const raw = node?.settings?.value
-  if (!raw) return null
+  const node = body.data.metaobjects.nodes[0];
+  const raw = node?.settings?.value;
+  if (!raw) return null;
 
   try {
-    const banner = JSON.parse(raw) as SiteBanner
+    const banner = JSON.parse(raw) as SiteBanner;
 
-    if (banner.ctaType === 'none') {
-      delete banner.linkUrl
-      delete banner.discountCode
+    if (banner.ctaType === "none") {
+      delete banner.linkUrl;
+      delete banner.discountCode;
     }
-    return banner
+    return banner;
   } catch {
-    console.warn('Invalid JSON in banner_settings metaobject')
-    return null
+    console.warn("Invalid JSON in banner_settings metaobject");
+    return null;
   }
 }

--- a/lib/shopify/types.ts
+++ b/lib/shopify/types.ts
@@ -8,7 +8,7 @@ export type Edge<T> = {
   node: T;
 };
 
-export type Cart = Omit<ShopifyCart, 'lines'> & {
+export type Cart = Omit<ShopifyCart, "lines"> & {
   lines: CartItem[];
 };
 
@@ -68,13 +68,20 @@ export type Page = {
   updatedAt: string;
 };
 
-export type Product = Omit<ShopifyProduct, 'variants' | 'images'| 
-'subtitle' | 'benefits' | 'ratingAverage' | 'internalRatings' > & {
+export type Product = Omit<
+  ShopifyProduct,
+  | "variants"
+  | "images"
+  | "subtitle"
+  | "benefits"
+  | "ratingAverage"
+  | "internalRatings"
+> & {
   variants: ProductVariant[];
   images: Image[];
-  subtitle?:       string;
-  benefits?:       string[];
-  ratingAverage?:  number;
+  subtitle?: string;
+  benefits?: string[];
+  ratingAverage?: number;
   internalRatings?: InternalRating[];
 };
 
@@ -92,6 +99,7 @@ export type ProductVariant = {
     name: string;
     value: string;
   }[];
+  image?: Image;
   price: Money;
 };
 
@@ -281,9 +289,9 @@ export type ShopifyProductsOperation = {
 };
 
 export interface InternalRating {
-  image:       string;
-  rating:      number;
-  title:       string;
+  image: string;
+  rating: number;
+  title: string;
   description: string;
 }
 
@@ -292,20 +300,20 @@ export interface Metafield {
 }
 
 export interface SiteBanner {
-  message:       string
-  ctaType:       'link' | 'copyCode' | 'none'
-  linkUrl?:      string
-  discountCode?: string
+  message: string;
+  ctaType: "link" | "copyCode" | "none";
+  linkUrl?: string;
+  discountCode?: string;
 }
 
 export interface GetSiteBannerResponse {
   data: any;
   metaobjects: {
     nodes: Array<{
-      id: string
-      settings: { value: string } | null
-    }>
-  }
+      id: string;
+      settings: { value: string } | null;
+    }>;
+  };
 }
 
 export interface SiteBannerBarProps {


### PR DESCRIPTION
## Summary
- add image to product fragment query
- support optional image on ProductVariant type
- reshape variant data to include variant image info
- show images instead of text buttons in `VariantSelector`

## Testing
- `pnpm test` *(fails: Code style issues found in 68 files)*

------
https://chatgpt.com/codex/tasks/task_e_684079d8508c8333a93d20d61c6540f1