### PR TITLE
Variant images for selection

### DIFF
--- a/components/product/variant-selector.tsx
+++ b/components/product/variant-selector.tsx
@@ -1,8 +1,9 @@
-'use client';
+"use client";
 
-import clsx from 'clsx';
-import { useProduct, useUpdateURL } from 'components/product/product-context';
-import { ProductOption, ProductVariant } from 'lib/shopify/types';
+import clsx from "clsx";
+import Image from "next/image";
+import { useProduct, useUpdateURL } from "components/product/product-context";
+import { ProductOption, ProductVariant } from "lib/shopify/types";
 
 type Combination = {
   id: string;
@@ -12,7 +13,7 @@ type Combination = {
 
 export function VariantSelector({
   options,
-  variants
+  variants,
 }: {
   options: ProductOption[];
   variants: ProductVariant[];
@@ -20,7 +21,8 @@ export function VariantSelector({
   const { state, updateOption } = useProduct();
   const updateURL = useUpdateURL();
   const hasNoOptionsOrJustOneOption =
-    !options.length || (options.length === 1 && options[0]?.values.length === 1);
+    !options.length ||
+    (options.length === 1 && options[0]?.values.length === 1);
 
   if (hasNoOptionsOrJustOneOption) {
     return null;
@@ -30,9 +32,12 @@ export function VariantSelector({
     id: variant.id,
     availableForSale: variant.availableForSale,
     ...variant.selectedOptions.reduce(
-      (accumulator, option) => ({ ...accumulator, [option.name.toLowerCase()]: option.value }),
-      {}
-    )
+      (accumulator, option) => ({
+        ...accumulator,
+        [option.name.toLowerCase()]: option.value,
+      }),
+      {},
+    ),
   }));
 
   return options.map((option) => (
@@ -47,16 +52,28 @@ export function VariantSelector({
             const optionParams = { ...state, [optionNameLowerCase]: value };
 
             // Filter out invalid options and check if the option combination is available for sale.
-            const filtered = Object.entries(optionParams).filter(([key, value]) =>
-              options.find(
-                (option) => option.name.toLowerCase() === key && option.values.includes(value)
-              )
+            const filtered = Object.entries(optionParams).filter(
+              ([key, value]) =>
+                options.find(
+                  (option) =>
+                    option.name.toLowerCase() === key &&
+                    option.values.includes(value),
+                ),
             );
             const isAvailableForSale = combinations.find((combination) =>
               filtered.every(
-                ([key, value]) => combination[key] === value && combination.availableForSale
-              )
+                ([key, value]) =>
+                  combination[key] === value && combination.availableForSale,
+              ),
             );
+
+            const variantImage = variants.find((variant) =>
+              variant.selectedOptions.some(
+                (o) =>
+                  o.name.toLowerCase() === optionNameLowerCase &&
+                  o.value === value,
+              ),
+            )?.image;
 
             // The option is active if it's in the selected options.
             const isActive = state[optionNameLowerCase] === value;
@@ -70,19 +87,29 @@ export function VariantSelector({
                 key={value}
                 aria-disabled={!isAvailableForSale}
                 disabled={!isAvailableForSale}
-                title={`${option.name} ${value}${!isAvailableForSale ? ' (Out of Stock)' : ''}`}
+                title={`${option.name} ${value}${!isAvailableForSale ? " (Out of Stock)" : ""}`}
                 className={clsx(
-                  'flex min-w-[48px] items-center justify-center rounded-full border bg-neutral-100 px-2 py-1 text-sm',
+                  "flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border bg-neutral-100 text-sm",
                   {
-                    'cursor-default ring-2 ring-blue-600': isActive,
-                    'ring-1 ring-transparent transition duration-300 ease-in-out hover:ring-blue-600':
+                    "cursor-default ring-2 ring-blue-600": isActive,
+                    "ring-1 ring-transparent transition duration-300 ease-in-out hover:ring-blue-600":
                       !isActive && isAvailableForSale,
-                    'relative z-10 cursor-not-allowed overflow-hidden bg-neutral-100 text-neutral-500 ring-1 ring-neutral-300 before:absolute before:inset-x-0 before:-z-10 before:h-px before:-rotate-45 before:bg-neutral-300 before:transition-transform':
-                      !isAvailableForSale
-                  }
+                    "relative z-10 cursor-not-allowed overflow-hidden bg-neutral-100 text-neutral-500 ring-1 ring-neutral-300 before:absolute before:inset-x-0 before:-z-10 before:h-px before:-rotate-45 before:bg-neutral-300 before:transition-transform":
+                      !isAvailableForSale,
+                  },
                 )}
               >
-                {value}
+                {variantImage ? (
+                  <Image
+                    src={variantImage.url}
+                    alt={variantImage.altText}
+                    width={48}
+                    height={48}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  value
+                )}
               </button>
             );
           })}

--- a/lib/shopify/fragments/product.ts
+++ b/lib/shopify/fragments/product.ts
@@ -1,6 +1,6 @@
-import imageFragment from './image';
-import { productExtrasFragment } from './productExtrasFragment';
-import seoFragment from './seo';
+import imageFragment from "./image";
+import { productExtrasFragment } from "./productExtrasFragment";
+import seoFragment from "./seo";
 
 const productFragment = /* GraphQL */ `
   fragment product on Product {
@@ -31,6 +31,9 @@ const productFragment = /* GraphQL */ `
           id
           title
           availableForSale
+          image {
+            ...image
+          }
           selectedOptions {
             name
             value

--- a/lib/shopify/types.ts
+++ b/lib/shopify/types.ts
@@ -8,7 +8,7 @@ export type Edge<T> = {
   node: T;
 };
 
-export type Cart = Omit<ShopifyCart, 'lines'> & {
+export type Cart = Omit<ShopifyCart, "lines"> & {
   lines: CartItem[];
 };
 
@@ -68,13 +68,20 @@ export type Page = {
   updatedAt: string;
 };
 
-export type Product = Omit<ShopifyProduct, 'variants' | 'images'| 
-'subtitle' | 'benefits' | 'ratingAverage' | 'internalRatings' > & {
+export type Product = Omit<
+  ShopifyProduct,
+  | "variants"
+  | "images"
+  | "subtitle"
+  | "benefits"
+  | "ratingAverage"
+  | "internalRatings"
+> & {
   variants: ProductVariant[];
   images: Image[];
-  subtitle?:       string;
-  benefits?:       string[];
-  ratingAverage?:  number;
+  subtitle?: string;
+  benefits?: string[];
+  ratingAverage?: number;
   internalRatings?: InternalRating[];
 };
 
@@ -88,6 +95,7 @@ export type ProductVariant = {
   id: string;
   title: string;
   availableForSale: boolean;
+  image?: Image;
   selectedOptions: {
     name: string;
     value: string;
@@ -281,9 +289,9 @@ export type ShopifyProductsOperation = {
 };
 
 export interface InternalRating {
-  image:       string;
-  rating:      number;
-  title:       string;
+  image: string;
+  rating: number;
+  title: string;
   description: string;
 }
 
@@ -292,20 +300,20 @@ export interface Metafield {
 }
 
 export interface SiteBanner {
-  message:       string
-  ctaType:       'link' | 'copyCode' | 'none'
-  linkUrl?:      string
-  discountCode?: string
+  message: string;
+  ctaType: "link" | "copyCode" | "none";
+  linkUrl?: string;
+  discountCode?: string;
 }
 
 export interface GetSiteBannerResponse {
   data: any;
   metaobjects: {
     nodes: Array<{
-      id: string
-      settings: { value: string } | null
-    }>
-  }
+      id: string;
+      settings: { value: string } | null;
+    }>;
+  };
 }
 
 export interface SiteBannerBarProps {


### PR DESCRIPTION
## Summary
- fetch variant image via Shopify product query
- store optional `image` on each `ProductVariant`
- show variant images in the selector instead of text labels

## Testing
- `npm test` *(fails: Code style issues found in 69 files)*

------
https://chatgpt.com/codex/tasks/task_e_6840801043f88333adc14c65b4f98807