### PR TITLE
Add videos metafield to Shopify product extras

### DIFF
--- a/lib/shopify/fragments/productExtrasFragment.ts
+++ b/lib/shopify/fragments/productExtrasFragment.ts
@@ -12,5 +12,8 @@ export const productExtrasFragment = `
   internalRatings: metafield(namespace: "custom", key: "internalRatings") {
     value
   }
+  videos: metafield(namespace: "PDP", key: "videos") {
+    value
+  }
 }
 `;


### PR DESCRIPTION
## Summary
- support `videos` metafield in `productExtrasFragment`
- ensure product queries use the updated fragment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68427d018a8083339f9ede568e5c63b6