### PR TITLE
Update product types for reels

### DIFF
--- a/lib/shopify/types.ts
+++ b/lib/shopify/types.ts
@@ -47,6 +47,12 @@ export type Image = {
   height: number;
 };
 
+export interface Reel {
+  id: string;
+  poster: string;
+  src: string;
+}
+
 export type Menu = {
   title: string;
   path: string;
@@ -76,6 +82,7 @@ export type Product = Omit<
   | "benefits"
   | "ratingAverage"
   | "internalRatings"
+  | "videos"
 > & {
   variants: ProductVariant[];
   images: Image[];
@@ -83,6 +90,7 @@ export type Product = Omit<
   benefits?: string[];
   ratingAverage?: number;
   internalRatings?: InternalRating[];
+  videos?: Reel[];
 };
 
 export type ProductOption = {
@@ -150,6 +158,7 @@ export type ShopifyProduct = {
   benefits?: { value: string } | null;
   ratingAverage?: { value: string } | null;
   internalRatings?: { value: string } | null;
+  videos?: { value: string } | null;
 };
 
 export type ShopifyCartOperation = {


### PR DESCRIPTION
## Summary
- extend ShopifyProduct with videos metafield
- add Reel interface
- include videos field in Product type

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68427e7bc2cc8333844dd0f3320704ee