### PR TITLE
Parse product videos

### DIFF
--- a/lib/shopify/index.ts
+++ b/lib/shopify/index.ts
@@ -39,6 +39,7 @@ import {
   GetSiteBannerResponse,
   Image,
   InternalRating,
+  Reel,
   Menu,
   Page,
   Product,
@@ -199,6 +200,7 @@ export const reshapeProduct = (
     benefits,
     ratingAverage,
     internalRatings,
+    videos,
     ...rest
   } = product;
 
@@ -212,6 +214,7 @@ export const reshapeProduct = (
   const internalRatingsArr = internalRatings?.value
     ? (JSON.parse(internalRatings.value) as InternalRating[])
     : [];
+  const videosArr = videos?.value ? (JSON.parse(videos.value) as Reel[]) : [];
 
   return {
     ...rest,
@@ -221,6 +224,7 @@ export const reshapeProduct = (
     benefits: benefitsArr,
     ratingAverage: ratingAverageNum,
     internalRatings: internalRatingsArr,
+    videos: videosArr,
   };
 };
 

--- a/lib/shopify/types.ts
+++ b/lib/shopify/types.ts
@@ -76,6 +76,7 @@ export type Product = Omit<
   | "benefits"
   | "ratingAverage"
   | "internalRatings"
+  | "videos"
 > & {
   variants: ProductVariant[];
   images: Image[];
@@ -83,6 +84,7 @@ export type Product = Omit<
   benefits?: string[];
   ratingAverage?: number;
   internalRatings?: InternalRating[];
+  videos?: Reel[];
 };
 
 export type ProductOption = {
@@ -150,6 +152,7 @@ export type ShopifyProduct = {
   benefits?: { value: string } | null;
   ratingAverage?: { value: string } | null;
   internalRatings?: { value: string } | null;
+  videos?: { value: string } | null;
 };
 
 export type ShopifyCartOperation = {
@@ -293,6 +296,12 @@ export interface InternalRating {
   rating: number;
   title: string;
   description: string;
+}
+
+export interface Reel {
+  id: string;
+  poster: string;
+  src: string;
 }
 
 export interface Metafield {


### PR DESCRIPTION
## Summary
- support product videos in Shopify types
- parse product videos in the Shopify data layer

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68427e8d63cc8333905cb84a35a0b767