### PR TITLE
Add before-after metafield support

### DIFF
--- a/components/product/product-description.tsx
+++ b/components/product/product-description.tsx
@@ -81,7 +81,12 @@ export function ProductDescription({ product }: { product: Product }) {
 
         <ProductReels videos={product.videos ?? []} />
 
-        <CompareDemo />
+        {product.beforeafter?.firstImage && product.beforeafter?.secondImage ? (
+          <CompareDemo
+            firstImage={product.beforeafter.firstImage}
+            secondImage={product.beforeafter.secondImage}
+          />
+        ) : null}
       </div>
     </>
   );

--- a/components/ui/compare.tsx
+++ b/components/ui/compare.tsx
@@ -89,7 +89,7 @@ export const Compare = ({
         setIsDragging(true);
       }
     },
-    [slideMode]
+    [slideMode],
   );
 
   const handleEnd = useCallback(() => {
@@ -110,17 +110,17 @@ export const Compare = ({
         });
       }
     },
-    [slideMode, isDragging]
+    [slideMode, isDragging],
   );
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => handleStart(e.clientX),
-    [handleStart]
+    [handleStart],
   );
   const handleMouseUp = useCallback(() => handleEnd(), [handleEnd]);
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => handleMove(e.clientX),
-    [handleMove]
+    [handleMove],
   );
 
   const handleTouchStart = useCallback(
@@ -128,7 +128,8 @@ export const Compare = ({
       if (!autoplay && e.touches[0]?.clientX) {
         handleStart(e.touches[0].clientX);
       }
-    },    [handleStart, autoplay]
+    },
+    [handleStart, autoplay],
   );
 
   const handleTouchEnd = useCallback(() => {
@@ -143,7 +144,7 @@ export const Compare = ({
         handleMove(e.touches[0].clientX);
       }
     },
-    [handleMove, autoplay]
+    [handleMove, autoplay],
   );
 
   return (
@@ -198,7 +199,7 @@ export const Compare = ({
             <motion.div
               className={cn(
                 "absolute inset-0 z-20 rounded-2xl shrink-0 w-full h-full select-none overflow-hidden",
-                firstImageClassName
+                firstImageClassName,
               )}
               style={{
                 clipPath: `inset(0 ${100 - sliderXPercent}% 0 0)`,
@@ -210,7 +211,7 @@ export const Compare = ({
                 src={firstImage}
                 className={cn(
                   "absolute inset-0  z-20 rounded-2xl shrink-0 w-full h-full select-none",
-                  firstImageClassName
+                  firstImageClassName,
                 )}
                 draggable={false}
               />
@@ -224,7 +225,7 @@ export const Compare = ({
           <motion.img
             className={cn(
               "absolute top-0 left-0 z-[19]  rounded-2xl w-full h-full select-none",
-              secondImageClassname
+              secondImageClassname,
             )}
             alt="second image"
             src={secondImage}

--- a/components/ui/compareDemo.tsx
+++ b/components/ui/compareDemo.tsx
@@ -1,11 +1,18 @@
 import { Compare } from "@/components/ui/compare";
 
-export function CompareDemo() {
+interface CompareDemoProps {
+  firstImage?: string;
+  secondImage?: string;
+}
+
+export function CompareDemo({ firstImage, secondImage }: CompareDemoProps) {
+  if (!firstImage || !secondImage) return null;
+
   return (
     <div className="p-4 border rounded-3xl dark:bg-neutral-900 bg-neutral-100  border-neutral-200 dark:border-neutral-800 px-4">
       <Compare
-        firstImage="https://assets.aceternity.com/code-problem.png"
-        secondImage="https://assets.aceternity.com/code-solution.png"
+        firstImage={firstImage}
+        secondImage={secondImage}
         firstImageClassName="object-cover object-left-top"
         secondImageClassname="object-cover object-left-top"
         className="h-[250px] w-[100%] md:h-[500px] md:w-[100%]"

--- a/lib/shopify/fragments/productExtrasFragment.ts
+++ b/lib/shopify/fragments/productExtrasFragment.ts
@@ -15,5 +15,8 @@ export const productExtrasFragment = `
   videos: metafield(namespace: "PDP", key: "videos") {
     value
   }
+  beforeafter: metafield(namespace: "custom", key: "beforeafter") {
+    value
+  }
 }
 `;

--- a/lib/shopify/index.ts
+++ b/lib/shopify/index.ts
@@ -62,6 +62,7 @@ import {
   ShopifyRemoveFromCartOperation,
   ShopifyUpdateCartOperation,
   ShopifyVideosOperation,
+  BeforeAfter,
   SiteBanner,
 } from "./types";
 
@@ -203,6 +204,7 @@ export const reshapeProduct = (
     ratingAverage,
     internalRatings,
     videos,
+    beforeafter,
     ...rest
   } = product;
 
@@ -217,8 +219,23 @@ export const reshapeProduct = (
     ? (JSON.parse(internalRatings.value) as InternalRating[])
     : [];
   const videosArr = videos?.value
-    ? (JSON.parse(videos.value) as string[]).map((id) => ({ id, src: "", sources: undefined }))
+    ? (JSON.parse(videos.value) as string[]).map((id) => ({
+        id,
+        src: "",
+        sources: undefined,
+      }))
     : [];
+  let beforeafterObj: BeforeAfter | undefined;
+  if (beforeafter?.value) {
+    try {
+      const arr = JSON.parse(beforeafter.value) as string[];
+      if (Array.isArray(arr) && arr.length >= 2) {
+        beforeafterObj = { firstImage: arr[0], secondImage: arr[1] };
+      }
+    } catch {
+      beforeafterObj = undefined;
+    }
+  }
 
   return {
     ...rest,
@@ -229,6 +246,7 @@ export const reshapeProduct = (
     ratingAverage: ratingAverageNum,
     internalRatings: internalRatingsArr,
     videos: videosArr,
+    beforeafter: beforeafterObj,
   };
 };
 const reshapeProducts = (products: ShopifyProduct[]) => {
@@ -265,8 +283,9 @@ export async function getVideos(ids: string[]): Promise<Reel[]> {
       );
       const src = mp4?.url ?? node.sources[0].url;
       videos.push({
-        id: node.id, src,
-        sources: undefined
+        id: node.id,
+        src,
+        sources: undefined,
       });
     }
   }
@@ -480,7 +499,11 @@ export async function getProduct(handle: string): Promise<Product | undefined> {
     const ids = product.videos.map((v) => v.id);
     const sources = await getVideos(ids);
     const map = new Map(sources.map((v) => [v.id, v.src]));
-    product.videos = ids.map((id) => ({ id, src: map.get(id) || "", sources: [] }));
+    product.videos = ids.map((id) => ({
+      id,
+      src: map.get(id) || "",
+      sources: [],
+    }));
   }
   return product;
 }

--- a/lib/shopify/types.ts
+++ b/lib/shopify/types.ts
@@ -83,6 +83,7 @@ export type Product = Omit<
   | "ratingAverage"
   | "internalRatings"
   | "videos"
+  | "beforeafter"
 > & {
   variants: ProductVariant[];
   images: Image[];
@@ -91,6 +92,7 @@ export type Product = Omit<
   ratingAverage?: number;
   internalRatings?: InternalRating[];
   videos?: Reel[];
+  beforeafter?: BeforeAfter;
 };
 
 export type ProductOption = {
@@ -159,6 +161,7 @@ export type ShopifyProduct = {
   ratingAverage?: { value: string } | null;
   internalRatings?: { value: string } | null;
   videos?: { value: string } | null;
+  beforeafter?: { value: string } | null;
 };
 
 export type ShopifyCartOperation = {
@@ -319,6 +322,11 @@ export interface InternalRating {
   rating: number;
   title: string;
   description: string;
+}
+
+export interface BeforeAfter {
+  firstImage: string;
+  secondImage: string;
 }
 
 export interface Reel {


### PR DESCRIPTION
## Summary
- include before/after metafield in `productExtrasFragment`
- support new metafield in Shopify types and product reshaping
- pass fetched images to `CompareDemo`
- update `CompareDemo` to accept dynamic images
- format `compare.tsx` for prettier compliance
- only render `CompareDemo` when both images exist
- parse before/after metafield as an array and map to `firstImage` and `secondImage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68441b3ce5608333aa212c9ec1176a81